### PR TITLE
debian integration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,7 @@ apt-get install -y apache2 libapache2-mod-wsgi
 ln -s /home/$USER/GoProApp /home/GoProApp
 rm /etc/apache2/sites-enabled/000-default
 ln -s /home/GoProApp/GoProApp/apache.conf /etc/apache2/sites-enabled/GoProApp.conf
+ln -s /etc/apache2/mods-available/wsgi.* /etc/apache2/mods-enabled/
 service apache2 restart
 
 echo "Configuring Upstart..."

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@
 # should be in the same directory as setup.py
 
 echo "Installing packages..."
-sudo apt-get install -y python python-pip
-sudo pip install -r requirements.txt
+apt-get install -y python python-pip
+pip install -r requirements.txt
 
 echo "Configuring Django..."
 key=$(tr -dc "[:alpha:]" < /dev/urandom | head -c 48)
@@ -20,15 +20,15 @@ git submodule update --init
 # remove the steps below if you don't want Apache and Upstart
 
 echo "Configuring Apache..."
-sudo apt-get install -y apache2 libapache2-mod-wsgi
-sudo ln -s /home/$USER/GoProApp /home/GoProApp
-sudo rm /etc/apache2/sites-enabled/000-default
-sudo ln -s /home/GoProApp/GoProApp/apache.conf /etc/apache2/sites-enabled/GoProApp.conf
-sudo service apache2 restart
+apt-get install -y apache2 libapache2-mod-wsgi
+ln -s /home/$USER/GoProApp /home/GoProApp
+rm /etc/apache2/sites-enabled/000-default
+ln -s /home/GoProApp/GoProApp/apache.conf /etc/apache2/sites-enabled/GoProApp.conf
+service apache2 restart
 
 echo "Configuring Upstart..."
 # upstart does not support symlinks
-sudo cp /home/GoProApp/GoProApp/upstart.conf /etc/init/gopro-proxy.conf
-sudo start gopro-proxy
+cp /home/GoProApp/GoProApp/upstart.conf /etc/init/gopro-proxy.conf
+start gopro-proxy
 
 echo "Good to go!"


### PR DESCRIPTION
as debian doesn't include the users in sudo group by default, i removed the "sudo" parts from the setup script.
I added the auto loading of mod_wsgi, otherwise users would get the following error:
"Syntax error on line 5 of /etc/apache2/sites-enabled/GoProApp.conf:
Invalid command 'WSGIScriptAlias', perhaps misspelled or defined by a module not included in the server configuration
Action 'configtest' failed.
The Apache error log may have more information.
 failed!"
Bye, and thanks for a good django project!
